### PR TITLE
Revert "Sync with Substrate (#6)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
- "cpufeatures 0.2.1",
+ "cpufeatures",
  "opaque-debug 0.3.0",
 ]
 
@@ -68,7 +68,7 @@ dependencies = [
  "cipher",
  "ctr",
  "ghash",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "approx"
@@ -212,7 +212,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2 0.4.2",
+ "socket2 0.4.1",
  "waker-fn",
  "winapi 0.3.9",
 ]
@@ -583,9 +583,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
 dependencies = [
  "memchr",
 ]
@@ -601,15 +601,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0796d76a983651b4a0ddda16203032759f2fd9103d9181f7c65c06ee8872e6"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
 
 [[package]]
 name = "byte-tools"
@@ -715,21 +715,21 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
+checksum = "f08493fa7707effc63254c66c6ea908675912493cd67952eda23c09fae2610b1"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher",
- "cpufeatures 0.1.5",
+ "cpufeatures",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
+checksum = "b6547abe025f4027edacd9edaa357aded014eecec42a5070d9b885c3c334aba2"
 dependencies = [
  "aead",
  "chacha20",
@@ -883,7 +883,6 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "scale-info",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
@@ -927,15 +926,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea47428dc9d2237f3c6bc134472edfd63ebba0af932e783506dcfd66f10d18a"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1102,22 +1092,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -1127,7 +1107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -1178,7 +1158,7 @@ dependencies = [
  "byteorder",
  "digest 0.8.1",
  "rand_core 0.5.1",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -1191,7 +1171,7 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -1355,7 +1335,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "zeroize",
 ]
 
@@ -1517,9 +1497,9 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
-version = "1.0.22"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+checksum = "80edafed416a46fb378521624fab1cfa2eb514784fd8921adbe8a8d8321da811"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
@@ -1537,7 +1517,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1555,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1563,7 +1543,6 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
- "scale-info",
  "sp-api",
  "sp-io",
  "sp-runtime",
@@ -1575,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "chrono",
@@ -1601,12 +1580,11 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "scale-info",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -1616,20 +1594,19 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96616f82e069102b95a72c87de4c84d2f87ef7f0f20630e78ce3824436483110"
+version = "14.0.0-dev"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
- "cfg-if 1.0.0",
  "parity-scale-codec",
- "scale-info",
  "serde",
+ "sp-core",
+ "sp-std",
 ]
 
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1639,7 +1616,6 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "paste",
- "scale-info",
  "serde",
  "smallvec",
  "sp-arithmetic",
@@ -1656,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1668,10 +1644,10 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support-procedural-tools-derive",
- "proc-macro-crate 1.1.0",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1680,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1690,12 +1666,11 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "log",
  "parity-scale-codec",
- "scale-info",
  "serde",
  "sp-core",
  "sp-io",
@@ -1707,13 +1682,12 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "scale-info",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -1722,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1749,6 +1723,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -2094,16 +2074,6 @@ checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
-dependencies = [
- "crypto-mac 0.7.0",
- "digest 0.8.1",
-]
-
-[[package]]
-name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
@@ -2120,17 +2090,6 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac 0.11.1",
  "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
-dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
- "hmac 0.7.1",
 ]
 
 [[package]]
@@ -2200,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.13"
+version = "0.14.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
+checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -2214,7 +2173,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.7",
- "socket2 0.4.2",
+ "socket2 0.4.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2424,9 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2641,9 +2600,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libloading"
@@ -2736,7 +2695,7 @@ dependencies = [
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.7.0",
@@ -2807,7 +2766,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "regex",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "smallvec",
  "unsigned-varint 0.7.0",
  "wasm-timer",
@@ -2847,7 +2806,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "smallvec",
  "uint",
  "unsigned-varint 0.7.0",
@@ -2872,7 +2831,7 @@ dependencies = [
  "log",
  "rand 0.8.4",
  "smallvec",
- "socket2 0.4.2",
+ "socket2 0.4.1",
  "void",
 ]
 
@@ -2909,7 +2868,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.8.4",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -3045,7 +3004,7 @@ dependencies = [
  "libc",
  "libp2p-core",
  "log",
- "socket2 0.4.2",
+ "socket2 0.4.1",
 ]
 
 [[package]]
@@ -3119,22 +3078,6 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
-dependencies = [
- "arrayref",
- "crunchy",
- "digest 0.8.1",
- "hmac-drbg 0.2.0",
- "rand 0.7.3",
- "sha2 0.8.2",
- "subtle 2.4.1",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
@@ -3142,13 +3085,13 @@ dependencies = [
  "arrayref",
  "base64 0.12.3",
  "digest 0.9.0",
- "hmac-drbg 0.3.0",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "typenum",
 ]
 
@@ -3161,13 +3104,13 @@ dependencies = [
  "arrayref",
  "base64 0.12.3",
  "digest 0.9.0",
- "hmac-drbg 0.3.0",
+ "hmac-drbg",
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "typenum",
 ]
 
@@ -3179,7 +3122,7 @@ checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
 dependencies = [
  "crunchy",
  "digest 0.9.0",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -3542,7 +3485,7 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "sha3",
  "unsigned-varint 0.5.1",
 ]
@@ -3556,7 +3499,7 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "unsigned-varint 0.7.0",
 ]
 
@@ -3566,7 +3509,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
 dependencies = [
- "proc-macro-crate 1.1.0",
+ "proc-macro-crate 1.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3625,11 +3568,11 @@ dependencies = [
 
 [[package]]
 name = "names"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a8690bf09abf659851e58cd666c3d37ac6af07c2bd7a9e332cfba471715775"
+checksum = "ef320dab323286b50fb5cdda23f61c796a72a89998ab565ca32525c5c556f2da"
 dependencies = [
- "rand 0.8.4",
+ "rand 0.3.23",
 ]
 
 [[package]]
@@ -3807,13 +3750,12 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-timestamp",
  "parity-scale-codec",
- "scale-info",
  "sp-application-crypto",
  "sp-consensus-aura",
  "sp-runtime",
@@ -3823,13 +3765,12 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "scale-info",
  "sp-authorship",
  "sp-runtime",
  "sp-std",
@@ -3838,14 +3779,13 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
  "parity-scale-codec",
- "scale-info",
  "sp-runtime",
  "sp-std",
 ]
@@ -3853,20 +3793,18 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "libsecp256k1 0.3.5",
  "log",
  "pallet-contracts-primitives",
  "pallet-contracts-proc-macro",
  "parity-scale-codec",
  "pwasm-utils",
- "rand 0.7.3",
- "scale-info",
+ "rand 0.8.4",
  "serde",
  "smallvec",
  "sp-core",
@@ -3880,11 +3818,10 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
- "scale-info",
  "serde",
  "sp-core",
  "sp-runtime",
@@ -3894,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3904,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -3923,11 +3860,10 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
- "scale-info",
  "sp-api",
  "sp-runtime",
  "sp-std",
@@ -3936,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3945,7 +3881,6 @@ dependencies = [
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
- "scale-info",
  "sp-application-crypto",
  "sp-core",
  "sp-finality-grandpa",
@@ -3959,13 +3894,12 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "safe-mix",
- "scale-info",
  "sp-runtime",
  "sp-std",
 ]
@@ -3973,7 +3907,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3981,7 +3915,6 @@ dependencies = [
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
- "scale-info",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -3994,12 +3927,11 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "scale-info",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -4008,14 +3940,13 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
  "parity-scale-codec",
- "scale-info",
  "sp-inherents",
  "sp-io",
  "sp-runtime",
@@ -4026,12 +3957,11 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "scale-info",
  "serde",
  "smallvec",
  "sp-core",
@@ -4043,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4060,7 +3990,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4089,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11263a97373b43da4b426edbb52ef99a7b51e2d9752ef56a7f8b356f48495a5"
+checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
 dependencies = [
  "arrayvec 0.7.1",
  "bitvec 0.20.4",
@@ -4103,11 +4033,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b157dc92b3db2bae522afb31b3843e91ae097eb01d66c72dda66a2e86bc3ca14"
+checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
 dependencies = [
- "proc-macro-crate 1.1.0",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4135,9 +4065,9 @@ dependencies = [
 
 [[package]]
 name = "parity-util-mem"
-version = "0.10.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
+checksum = "7ad6f1acec69b95caf435bbd158d486e5a0a44fcf51531e84922c59ff09e8457"
 dependencies = [
  "cfg-if 1.0.0",
  "hashbrown",
@@ -4432,7 +4362,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
- "cpufeatures 0.2.1",
+ "cpufeatures",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -4444,7 +4374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if 1.0.0",
- "cpufeatures 0.2.1",
+ "cpufeatures",
  "opaque-debug 0.3.0",
  "universal-hash",
 ]
@@ -4464,7 +4394,6 @@ dependencies = [
  "fixed-hash",
  "impl-codec",
  "impl-serde",
- "scale-info",
  "uint",
 ]
 
@@ -4479,9 +4408,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
 dependencies = [
  "thiserror",
  "toml",
@@ -4663,6 +4592,29 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -4709,6 +4661,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -4727,9 +4694,9 @@ dependencies = [
 
 [[package]]
 name = "rand_distr"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964d548f8e7d12e102ef183a0de7e98180c9f8729f555897a857b96e48122d2f"
+checksum = "051b398806e42b9cd04ad9ec8f81e355d0a382c543ac6672c62f5a5b452ef142"
 dependencies = [
  "num-traits",
  "rand 0.8.4",
@@ -4791,6 +4758,15 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -5010,6 +4986,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cada0ef59efa6a5f4dc5e491f93d9f31e3fc7758df421ff1de8a706338e1100"
+dependencies = [
+ "byteorder",
+ "twox-hash",
+]
+
+[[package]]
 name = "rw-stream-sink"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5056,7 +5042,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log",
  "sp-core",
@@ -5067,7 +5053,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -5090,7 +5076,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5106,7 +5092,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5122,9 +5108,9 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
- "proc-macro-crate 1.1.0",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5133,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -5171,7 +5157,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "fnv",
  "futures 0.3.17",
@@ -5199,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -5224,7 +5210,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -5248,7 +5234,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5277,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -5303,7 +5289,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "lazy_static",
  "libsecp256k1 0.6.0",
@@ -5329,7 +5315,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "derive_more",
  "environmental",
@@ -5347,7 +5333,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5363,7 +5349,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -5382,7 +5368,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5419,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.17",
@@ -5436,7 +5422,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5451,7 +5437,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -5469,7 +5455,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5520,7 +5506,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -5536,7 +5522,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
@@ -5563,7 +5549,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.17",
  "libp2p",
@@ -5576,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5585,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.17",
  "hash-db",
@@ -5616,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.17",
  "jsonrpc-core",
@@ -5641,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.17",
  "jsonrpc-core",
@@ -5652,13 +5638,12 @@ dependencies = [
  "log",
  "serde_json",
  "substrate-prometheus-endpoint",
- "tokio",
 ]
 
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "directories",
@@ -5715,7 +5700,6 @@ dependencies = [
  "substrate-prometheus-endpoint",
  "tempfile",
  "thiserror",
- "tokio",
  "tracing",
  "tracing-futures",
 ]
@@ -5723,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5737,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "chrono",
  "futures 0.3.17",
@@ -5755,7 +5739,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5784,9 +5768,9 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
- "proc-macro-crate 1.1.0",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5795,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.17",
  "intervalier",
@@ -5822,7 +5806,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "derive_more",
  "futures 0.3.17",
@@ -5836,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.17",
  "futures-timer 3.0.2",
@@ -5855,7 +5839,6 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
- "serde",
 ]
 
 [[package]]
@@ -5864,7 +5847,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
 dependencies = [
- "proc-macro-crate 1.1.0",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5894,7 +5877,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "sha2 0.8.2",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -6017,9 +6000,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "itoa",
  "ryu",
@@ -6046,7 +6029,7 @@ checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures 0.2.1",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -6065,13 +6048,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.8"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures 0.2.1",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -6180,8 +6163,8 @@ dependencies = [
  "rand_core 0.6.3",
  "ring",
  "rustc_version 0.3.3",
- "sha2 0.9.8",
- "subtle 2.4.1",
+ "sha2 0.9.6",
+ "subtle",
  "x25519-dalek",
 ]
 
@@ -6198,9 +6181,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -6225,7 +6208,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "log",
@@ -6242,10 +6225,10 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "blake2-rfc",
- "proc-macro-crate 1.1.0",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -6254,10 +6237,9 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
- "scale-info",
  "serde",
  "sp-core",
  "sp-io",
@@ -6267,12 +6249,11 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "integer-sqrt",
  "num-traits",
  "parity-scale-codec",
- "scale-info",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -6282,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6294,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6306,7 +6287,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.17",
  "log",
@@ -6324,7 +6305,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
@@ -6343,11 +6324,10 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "scale-info",
  "sp-api",
  "sp-application-crypto",
  "sp-consensus",
@@ -6361,10 +6341,9 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
- "scale-info",
  "sp-arithmetic",
  "sp-runtime",
 ]
@@ -6372,7 +6351,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6395,11 +6374,10 @@ dependencies = [
  "primitive-types",
  "rand 0.7.3",
  "regex",
- "scale-info",
  "schnorrkel",
  "secrecy",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -6417,7 +6395,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.2",
@@ -6426,7 +6404,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6436,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6447,12 +6425,11 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "finality-grandpa",
  "log",
  "parity-scale-codec",
- "scale-info",
  "serde",
  "sp-api",
  "sp-application-crypto",
@@ -6465,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -6479,7 +6456,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "futures 0.3.17",
  "hash-db",
@@ -6504,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6515,7 +6492,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -6532,15 +6509,16 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
+ "ruzstd",
  "zstd",
 ]
 
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6550,7 +6528,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "backtrace",
 ]
@@ -6558,7 +6536,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -6568,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6578,7 +6556,6 @@ dependencies = [
  "parity-util-mem",
  "paste",
  "rand 0.7.3",
- "scale-info",
  "serde",
  "sp-application-crypto",
  "sp-arithmetic",
@@ -6590,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6607,10 +6584,10 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
- "proc-macro-crate 1.1.0",
+ "proc-macro-crate 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -6619,7 +6596,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6633,7 +6610,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "serde",
  "serde_json",
@@ -6642,10 +6619,9 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
- "scale-info",
  "sp-api",
  "sp-core",
  "sp-runtime",
@@ -6656,10 +6632,9 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
- "scale-info",
  "sp-runtime",
  "sp-std",
 ]
@@ -6667,7 +6642,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "log",
@@ -6690,12 +6665,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -6708,7 +6683,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log",
  "sp-core",
@@ -6721,7 +6696,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -6737,7 +6712,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "erased-serde",
  "log",
@@ -6755,7 +6730,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -6764,12 +6739,11 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-trait",
  "log",
  "parity-scale-codec",
- "scale-info",
  "sp-core",
  "sp-inherents",
  "sp-runtime",
@@ -6780,12 +6754,11 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "memory-db",
  "parity-scale-codec",
- "scale-info",
  "sp-core",
  "sp-std",
  "trie-db",
@@ -6795,12 +6768,11 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "parity-wasm 0.42.2",
- "scale-info",
  "serde",
  "sp-runtime",
  "sp-std",
@@ -6811,7 +6783,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -6822,7 +6794,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6921,14 +6893,14 @@ dependencies = [
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
  "schnorrkel",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "zeroize",
 ]
 
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "platforms",
 ]
@@ -6936,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.17",
@@ -6958,7 +6930,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "async-std",
  "derive_more",
@@ -6972,7 +6944,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#50c84cb8f92b6446b4a7b3043684b116aaea6866"
+source = "git+https://github.com/paritytech/substrate#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "ansi_term 0.12.1",
  "build-helper",
@@ -6983,12 +6955,6 @@ dependencies = [
  "walkdir",
  "wasm-gc-api",
 ]
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -7124,7 +7090,7 @@ dependencies = [
  "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "thiserror",
  "unicode-normalization",
  "zeroize",
@@ -7141,9 +7107,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.4.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5241dd6f21443a3606b432718b166d3cedc962fd4b8bea54a8bc7f514ebda986"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7225,9 +7191,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.28"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite 0.2.7",
@@ -7237,9 +7203,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.16"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d0dd09fa59a1b79c6750ad80dbda6b75f4e71c437a6a1a8cb91a8bcbd77"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7248,9 +7214,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.20"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -7288,9 +7254,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.24"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd0568dbfe3baf7048b7908d2b32bca0d81cd56bec6d2a8f894b01d74f86be3"
+checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -7446,9 +7412,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
@@ -7463,7 +7429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.4.1",
+ "subtle",
 ]
 
 [[package]]
@@ -7600,9 +7566,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -7610,9 +7576,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -7625,9 +7591,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -7637,9 +7603,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7647,9 +7613,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7660,9 +7626,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "wasm-gc-api"
@@ -7767,7 +7733,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
- "sha2 0.9.8",
+ "sha2 0.9.6",
  "toml",
  "winapi 0.3.9",
  "zstd",
@@ -7912,9 +7878,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8060,9 +8026,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ as the `Cargo.lock` in those repositories ‒ ensuring that the last
 known-to-work version of the dependencies are used.
 
 The latest confirmed working Substrate commit which will then be used is
-[50c84cb8f92b6446b4a7b3043684b116aaea6866](https://github.com/paritytech/substrate/tree/50c84cb8f92b6446b4a7b3043684b116aaea6866).
+[b391b82954ad95a927a921035e3017c4a0aad516](https://github.com/paritytech/substrate/tree/b391b82954ad95a927a921035e3017c4a0aad516).
 
 ## Usage
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,7 +13,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 
 pallet-aura = { git = "https://github.com/paritytech/substrate", package = "pallet-aura", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", package = "pallet-balances", default-features = false }
@@ -62,7 +61,6 @@ default = [
 ]
 std = [
 	"codec/std",
-	"scale-info/std",
 	"frame-executive/std",
 	"frame-support/std",
 	"frame-system-rpc-runtime-api/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -415,7 +415,7 @@ impl_runtime_apis! {
 
 	impl sp_api::Metadata<Block> for Runtime {
 		fn metadata() -> OpaqueMetadata {
-			OpaqueMetadata::new(Runtime::metadata().into())
+			Runtime::metadata().into()
 		}
 	}
 


### PR DESCRIPTION
This reverts commit 8d91b8e578065a7c06433cbd41ac059bf478a0bd.

We have to revert to the `Cargo.lock` from before the Metadata update. This is because the UI's don't yet support it.