### PR TITLE
add shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,27 @@
+let
+  mozillaOverlay =
+    import (builtins.fetchGit {
+      url = "https://github.com/mozilla/nixpkgs-mozilla.git";
+      rev = "4a07484cf0e49047f82d83fd119acffbad3b235f";
+    });
+  nixpkgs = import <nixpkgs> { overlays = [ mozillaOverlay ]; };
+  rust-nightly = with nixpkgs; ((rustChannelOf { date = "2021-12-30"; channel = "nightly"; }).rust.override {
+    extensions = [ "rust-src" ];
+    targets = [ "wasm32-unknown-unknown" ];
+  });
+in
+with nixpkgs; pkgs.mkShell {
+  buildInputs = [
+    clang
+    openssl.dev
+    pkg-config
+    rust-nightly
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+
+  RUST_SRC_PATH = "${rust-nightly}/lib/rustlib/src/rust/src";
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+  PROTOC = "${protobuf}/bin/protoc";
+  ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+}


### PR DESCRIPTION
pretty much identical to https://github.com/paritytech/substrate/blob/master/shell.nix (rust nightly version is `2021-12-30` instead)
quite useful for nix setups