### PR TITLE
Make `--dev` default behavior and highlight modifications that have been made for non-production use

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ configured to include Substrate's [`pallet-contracts`](https://github.com/parity
 
 This repository is tracking Substrate's `master`.
 
+_It contains a couple of modifications that make it unsuitable for
+production, but a great fit for development and testing:_
+
+* The unstable features of the [`pallet-contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
+  are enabled by default (see the [`runtime/Cargo.toml`](https://github.com/paritytech/substrate-contracts-node/blob/main/runtime/Cargo.toml).
+* The consensus algorithm has been switched to `manual-seal` in
+  [#42](https://github.com/paritytech/substrate-contracts-node/pull/42).
+  Hereby blocks are authored immediately at every transaction, so there
+  is none of the typical six second block time associated with `grandpa` or `aura`.
+* If no CLI arguments are passed the node is started in development mode
+  by default.
+
+If you are looking for a node suitable for production use we have these pointers:
+
+* [Substrate Node Template](https://github.com/paritytech/substrate/tree/master/bin/node-template)
+* [Substrate Cumulus Parachain Template](https://github.com/paritytech/cumulus/tree/master/parachain-template)
+* [Canvas Parachain Configuration for Rococo](https://github.com/paritytech/cumulus/tree/master/polkadot-parachains/canvas-kusama)
+
 ## Installation
 
 Follow the [official installation steps](https://docs.substrate.io/v3/getting-started/installation/)

--- a/README.md
+++ b/README.md
@@ -10,21 +10,28 @@ _It contains a couple of modifications that make it unsuitable for
 production, but a great fit for development and testing:_
 
 * The unstable features of the [`pallet-contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
-  are enabled by default (see the [`runtime/Cargo.toml`](https://github.com/paritytech/substrate-contracts-node/blob/main/runtime/Cargo.toml).
+  are enabled by default (see the [`runtime/Cargo.toml`](https://github.com/paritytech/substrate-contracts-node/blob/main/runtime/Cargo.toml)).
 * The consensus algorithm has been switched to `manual-seal` in
   [#42](https://github.com/paritytech/substrate-contracts-node/pull/42).
   Hereby blocks are authored immediately at every transaction, so there
-  is none of the typical six second block time associated with `grandpa` or `aura`.
+  is none of the typical six seconds block time associated with `grandpa` or `aura`.
 * If no CLI arguments are passed the node is started in development mode
   by default.
 
-If you are looking for a node suitable for production use we have these pointers:
+If you are looking for a node suitable for production see these configurations:
 
 * [Substrate Node Template](https://github.com/paritytech/substrate/tree/master/bin/node-template)
 * [Substrate Cumulus Parachain Template](https://github.com/paritytech/cumulus/tree/master/parachain-template)
 * [Canvas Parachain Configuration for Rococo](https://github.com/paritytech/cumulus/tree/master/polkadot-parachains/canvas-kusama)
 
 ## Installation
+
+### Download Binary
+
+The easiest way is to download a binary release from [our releases page](https://github.com/paritytech/substrate-contracts-node/releases)
+and just execute `./substrate-contracts-node --dev`.
+
+### Build Locally
 
 Follow the [official installation steps](https://docs.substrate.io/v3/getting-started/installation/)
 to set up all Substrate prerequisites.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ configured to include Substrate's [`pallet-contracts`](https://github.com/parity
 
 This repository is tracking Substrate's `master`.
 
-_It contains a couple of modifications that make it unsuitable for
-production, but a great fit for development and testing:_
+_It contains a couple of modifications that make it unsuitable for a
+production deployment, but a great fit for development and testing:_
 
 * The unstable features of the [`pallet-contracts`](https://github.com/paritytech/substrate/tree/master/frame/contracts)
   are enabled by default (see the [`runtime/Cargo.toml`](https://github.com/paritytech/substrate-contracts-node/blob/main/runtime/Cargo.toml)).

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -38,8 +38,8 @@ impl SubstrateCli for Cli {
 
 	fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
 		Ok(match id {
-			"dev" => Box::new(chain_spec::development_config()?),
-			"" | "local" => Box::new(chain_spec::local_testnet_config()?),
+			"" | "dev" => Box::new(chain_spec::development_config()?),
+			"local" => Box::new(chain_spec::local_testnet_config()?),
 			path =>
 				Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),
 		})

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -29,7 +29,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn support_url() -> String {
-		"https://github.com/paritytech/canvas-node/issues/new".into()
+		"https://github.com/paritytech/substrate-contracts-node/issues/new".into()
 	}
 
 	fn copyright_start_year() -> i32 {


### PR DESCRIPTION
Closes https://github.com/paritytech/substrate-contracts-node/issues/54 and https://github.com/paritytech/substrate-contracts-node/issues/51.

[Preview here](https://github.com/paritytech/substrate-contracts-node/tree/cmichi-make-dev-default#substrate-contracts-node).