### PR TITLE
add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,7 @@
 version: 2
 
 updates:
-  - package-ecosystem: npm
+  - package-ecosystem: "cargo"
     directory: "/"
-    labels:
-    - "automerge"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 4
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    labels:
+    - "automerge"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 4


### PR DESCRIPTION
This PR adds `dependabot` to repository. To automate dependency updates and security vulnerabilities fixes.  
Related issue https://github.com/paritytech/ci_cd/issues/114