### PR TITLE
Prevent Dependabot from updating Substrate related crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,20 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: frame-*
+        versions:
+          - ">= 0"
+      - dependency-name: pallet-*
+        versions:
+          - ">= 0"
+      - dependency-name: sc-*
+        versions:
+          - ">= 0"
+      - dependency-name: sp-*
+        versions:
+          - ">= 0"
+      - dependency-name: substrate-*
+        versions:
+          - ">= 0"


### PR DESCRIPTION
Recently Dependabot has been spamming this repo trying to update Substrate related
crates. We manually update Substrate and friends anyways, so this is unnecessary.
