### PR TITLE
Make Dependabot ignore more dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,9 @@ updates:
       - dependency-name: substrate-*
         versions:
           - ">= 0"
+      - dependency-name: try-runtime-cli
+        versions:
+          - ">= 0"
+      - dependency-name: jsonrpsee
+        versions:
+          - ">= 0"


### PR DESCRIPTION
These should only really be updated alongside our Substrate bumps.
