### PR TITLE
Various improvements + Sync with substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1651,7 +1651,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "Inflector",
  "chrono",
@@ -1702,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -1744,6 +1744,7 @@ dependencies = [
  "scale-info",
  "serde",
  "smallvec",
+ "sp-api",
  "sp-arithmetic",
  "sp-core",
  "sp-core-hashing-proc-macro",
@@ -1760,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -1772,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1784,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1794,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-support",
  "log",
@@ -1811,7 +1812,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1826,7 +1827,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -1835,7 +1836,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-support",
  "sp-api",
@@ -3966,7 +3967,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3981,7 +3982,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3996,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -4023,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -4038,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4048,7 +4049,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "jsonrpsee",
  "pallet-contracts-primitives",
@@ -4065,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -4078,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4092,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4106,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4124,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4140,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -4155,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4917,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "env_logger",
  "jsonrpsee",
@@ -5161,7 +5162,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "log",
  "sp-core",
@@ -5172,7 +5173,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5195,7 +5196,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5211,7 +5212,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2 0.5.5",
@@ -5228,7 +5229,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5239,7 +5240,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "chrono",
  "clap",
@@ -5278,7 +5279,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "fnv",
  "futures",
@@ -5306,7 +5307,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -5331,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "futures",
@@ -5355,7 +5356,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "futures",
@@ -5384,7 +5385,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -5426,7 +5427,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5439,7 +5440,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5473,7 +5474,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "futures",
@@ -5498,7 +5499,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "lazy_static",
  "lru",
@@ -5525,14 +5526,13 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "environmental",
  "parity-scale-codec",
  "sc-allocator",
  "sp-maybe-compressed-blob",
  "sp-sandbox",
- "sp-serializer",
  "sp-wasm-interface",
  "thiserror",
  "wasm-instrument",
@@ -5542,7 +5542,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5557,7 +5557,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5577,7 +5577,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "ansi_term",
  "futures",
@@ -5585,7 +5585,7 @@ dependencies = [
  "log",
  "parity-util-mem",
  "sc-client-api",
- "sc-network",
+ "sc-network-common",
  "sc-transaction-pool-api",
  "sp-blockchain",
  "sp-runtime",
@@ -5594,7 +5594,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "hex",
@@ -5609,7 +5609,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -5658,9 +5658,11 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
+ "async-trait",
  "bitflags",
+ "bytes",
  "futures",
  "libp2p",
  "parity-scale-codec",
@@ -5671,12 +5673,13 @@ dependencies = [
  "sp-consensus",
  "sp-finality-grandpa",
  "sp-runtime",
+ "thiserror",
 ]
 
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures",
  "hex",
@@ -5697,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "fork-tree",
  "futures",
@@ -5725,7 +5728,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "bytes",
  "fnv",
@@ -5741,6 +5744,7 @@ dependencies = [
  "rand 0.7.3",
  "sc-client-api",
  "sc-network",
+ "sc-network-common",
  "sc-utils",
  "sp-api",
  "sp-core",
@@ -5753,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures",
  "libp2p",
@@ -5766,7 +5770,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -5775,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures",
  "hash-db",
@@ -5805,7 +5809,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -5828,7 +5832,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -5841,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "directories",
@@ -5908,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5922,7 +5926,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures",
  "libc",
@@ -5941,7 +5945,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "chrono",
  "futures",
@@ -5959,7 +5963,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "ansi_term",
  "atty",
@@ -5990,7 +5994,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6001,7 +6005,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6027,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures",
  "log",
@@ -6040,7 +6044,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures",
  "futures-timer",
@@ -6464,7 +6468,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "hash-db",
  "log",
@@ -6481,7 +6485,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -6493,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6506,7 +6510,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6521,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6533,7 +6537,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6545,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures",
  "log",
@@ -6563,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "futures",
@@ -6582,7 +6586,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -6600,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "merlin",
@@ -6623,7 +6627,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6637,7 +6641,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6650,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "base58",
  "bitflags",
@@ -6696,7 +6700,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "blake2",
  "byteorder",
@@ -6710,7 +6714,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6721,7 +6725,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -6730,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6740,7 +6744,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6751,7 +6755,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -6769,7 +6773,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -6783,7 +6787,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "bytes",
  "futures",
@@ -6809,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -6820,7 +6824,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "futures",
@@ -6837,7 +6841,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "thiserror",
  "zstd",
@@ -6846,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -6856,7 +6860,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -6866,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -6876,7 +6880,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -6898,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -6916,7 +6920,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -6928,7 +6932,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -6940,18 +6944,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-serializer"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6965,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -6976,7 +6971,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "hash-db",
  "log",
@@ -6998,12 +6993,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7016,7 +7011,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "log",
  "sp-core",
@@ -7029,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -7045,7 +7040,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -7057,7 +7052,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -7066,7 +7061,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "async-trait",
  "log",
@@ -7082,7 +7077,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7098,7 +7093,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -7115,7 +7110,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -7126,7 +7121,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -7226,7 +7221,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "platforms",
 ]
@@ -7234,7 +7229,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -7255,7 +7250,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "futures-util",
  "hyper",
@@ -7268,7 +7263,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -7717,7 +7712,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate#74a6370e805ebaf88b7939e496818531f762cadf"
+source = "git+https://github.com/paritytech/substrate#6b8553511112afd5ae7e8e6877dc2f467850f155"
 dependencies = [
  "clap",
  "jsonrpsee",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [workspace]
+resolver = "2"
 members = [
     'node',
     'runtime',
 ]
+
 [profile.release]
 panic = 'unwind'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ configured to include Substrate's [`pallet-contracts`](https://github.com/parity
 
 This repository is tracking Substrate's `master`.
 The last time it was synchronized with Substrate was up to
-[74a6370](https://github.com/paritytech/substrate/tree/74a6370e805ebaf88b7939e496818531f762cadf).
+[6b85535](https://github.com/paritytech/substrate/tree/6b8553511112afd5ae7e8e6877dc2f467850f155).
 
 _This repository contains a couple of modifications that make it unsuitable
 for a production deployment, but a great fit for development and testing:_

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ for a production deployment, but a great fit for development and testing:_
   is none of the typical six seconds block time associated with `grandpa` or `aura`.
 * _If no CLI arguments are passed the node is started in development mode
   by default._
-* A custom logging filter is applied by default that hides block production noise and prints the contracts debug
-  buffer to the console.
+* A custom logging filter is applied by default that hides block production noise
+  and prints the contracts debug buffer to the console.
 * _With each start of the node process the chain starts from genesis ‒ so no
   chain state is retained, all contracts will be lost! If you want to retain
   chain state you have to supply a `--base-path`._

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ for a production deployment, but a great fit for development and testing:_
   is none of the typical six seconds block time associated with `grandpa` or `aura`.
 * _If no CLI arguments are passed the node is started in development mode
   by default._
+* A custom logging filter is applied by default that hides block production noise and prints the contracts debug
+  buffer to the console.
 * _With each start of the node process the chain starts from genesis ‒ so no
   chain state is retained, all contracts will be lost! If you want to retain
   chain state you have to supply a `--base-path`._
@@ -38,7 +40,7 @@ If you are looking for a node suitable for production see these configurations:
 ### Download Binary
 
 The easiest way is to download a binary release from [our releases page](https://github.com/paritytech/substrate-contracts-node/releases)
-and just execute `./substrate-contracts-node --dev`.
+and just execute `./substrate-contracts-node`.
 
 ### Build Locally
 
@@ -63,11 +65,11 @@ The latest confirmed working Substrate commit which will then be used is
 To run a local dev node execute
 
 ```bash
-substrate-contracts-node --dev
+substrate-contracts-node
 ```
 
 A new chain in temporary directory will be created each time the command is executed. This is the
-default for `--dev` chain specs. If you want to persist chain state across runs you need to
+default for this node. If you want to persist chain state across runs you need to
 specify a directory with `--base-path`.
 
 ### Show only Errors and Contract Debug Output

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -59,6 +59,16 @@ pub fn run() -> sc_cli::Result<()> {
 		cli.run.shared_params.dev = true;
 	}
 
+	// remove block production noise and output contracts debug buffer by default
+	if cli.run.shared_params.log.is_empty() {
+		cli.run.shared_params.log = vec![
+			"runtime::contracts=debug".into(),
+			"sc_cli=info".into(),
+			"sc_rpc_server=info".into(),
+			"warn".into(),
+		];
+	}
+
 	match &cli.subcommand {
 		Some(Subcommand::Key(cmd)) => cmd.run(&cli),
 		Some(Subcommand::BuildSpec(cmd)) => {

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -52,7 +52,12 @@ impl SubstrateCli for Cli {
 
 /// Parse and run command line arguments
 pub fn run() -> sc_cli::Result<()> {
-	let cli = Cli::from_args();
+	let mut cli = Cli::from_args();
+
+	// this is a development node: make dev chain spec the default
+	if cli.run.shared_params.chain.is_none() {
+		cli.run.shared_params.dev = true;
+	}
 
 	match &cli.subcommand {
 		Some(Subcommand::Key(cmd)) => cmd.run(&cli),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -467,6 +467,21 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl pallet_transaction_payment_rpc_runtime_api::TransactionPaymentCallApi<Block, Balance, Call> for Runtime {
+		fn query_call_info(
+			call: Call,
+			len: u32,
+		) -> pallet_transaction_payment::RuntimeDispatchInfo<Balance> {
+			TransactionPayment::query_call_info(call, len)
+		}
+		fn query_call_fee_details(
+			call: Call,
+			len: u32,
+		) -> pallet_transaction_payment::FeeDetails<Balance> {
+			TransactionPayment::query_call_fee_details(call, len)
+		}
+	}
+
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
 		fn benchmark_metadata(extra: bool) -> (


### PR DESCRIPTION
- Sync with substrate
- Use new resolver
- Add support for https://github.com/paritytech/substrate/pull/11819
- Make `--dev` the default
- Add sane log filtering (reduce block production noise and print contracts debug buffer by default)