### PR TITLE
CallFilter: allow call to Balances' `transfer_allow_death()`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,6 +91,7 @@ build-mac:
     - unset CARGO_TARGET_DIR
   script:
     - time cargo build --release --target aarch64-apple-darwin
+    - rustup target add x86_64-apple-darwin
     - time cargo build --release --target x86_64-apple-darwin
     - mkdir -p ./artifacts/substrate-contracts-node-mac/
     - 'lipo

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -330,7 +330,7 @@ pub enum AllowBalancesCall {}
 
 impl frame_support::traits::Contains<RuntimeCall> for AllowBalancesCall {
 	fn contains(call: &RuntimeCall) -> bool {
-		matches!(call, RuntimeCall::Balances(BalancesCall::transfer_allow_death {..}))
+		matches!(call, RuntimeCall::Balances(BalancesCall::transfer_allow_death { .. }))
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -326,6 +326,14 @@ impl pallet_utility::Config for Runtime {
 	type WeightInfo = pallet_utility::weights::SubstrateWeight<Runtime>;
 }
 
+pub enum AllowBalancesCall {}
+
+impl frame_support::traits::Contains<RuntimeCall> for AllowBalancesCall {
+	fn contains(call: &RuntimeCall) -> bool {
+		matches!(call, RuntimeCall::Balances(BalancesCall::transfer_allow_death {..}))
+	}
+}
+
 impl pallet_contracts::Config for Runtime {
 	type Time = Timestamp;
 	type Randomness = RandomnessCollectiveFlip;
@@ -339,7 +347,7 @@ impl pallet_contracts::Config for Runtime {
 	/// and make sure they are stable. Dispatchables exposed to contracts are not allowed to
 	/// change because that would break already deployed contracts. The `RuntimeCall` structure
 	/// itself is not allowed to change the indices of existing pallets, too.
-	type CallFilter = frame_support::traits::Nothing;
+	type CallFilter = AllowBalancesCall;
 	type DepositPerItem = DepositPerItem;
 	type DepositPerByte = DepositPerByte;
 	type CallStack = [pallet_contracts::Frame<Self>; 31];


### PR DESCRIPTION
This is needed in order to make the e2e test for [call_runtime](https://github.com/paritytech/ink/blob/e267dd15730c3d19d5030fa440292f849acf9960/integration-tests/call-runtime/lib.rs#L150) pass