### PR TITLE
Customize schedule with runtime memory limit suitable for development node

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ build-linux:
   <<:                              *build-refs
   script:
     - time cargo build --release
-    # - time cargo test --release --all
+    - time cargo test --release --all
     - mkdir -p ./artifacts/substrate-contracts-node-linux/
     - cp target/release/substrate-contracts-node ./artifacts/substrate-contracts-node-linux/substrate-contracts-node
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -23,6 +23,7 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
+
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
 	construct_runtime, parameter_types,
@@ -359,7 +360,7 @@ impl pallet_contracts::Config for Runtime {
 	type CallFilter = AllowBalancesCall;
 	type DepositPerItem = DepositPerItem;
 	type DepositPerByte = DepositPerByte;
-	type CallStack = [pallet_contracts::Frame<Self>; 5];
+	type CallStack = [pallet_contracts::Frame<Self>; 23];
 	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
 	type WeightInfo = pallet_contracts::weights::SubstrateWeight<Self>;
 	type ChainExtension = pallet_assets_chain_extension::substrate::AssetsExtension;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -23,7 +23,6 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
 	construct_runtime, parameter_types,
@@ -132,6 +131,16 @@ pub const EXISTENTIAL_DEPOSIT: Balance = MILLIUNIT;
 
 const fn deposit(items: u32, bytes: u32) -> Balance {
 	(items as Balance * UNIT + (bytes as Balance) * (5 * MILLIUNIT / 100)) / 10
+}
+
+fn schedule<T: pallet_contracts::Config>() -> pallet_contracts::Schedule<T> {
+	pallet_contracts::Schedule {
+		limits: pallet_contracts::Limits {
+			runtime_memory: 1024 * 1024 * 1024,
+			..Default::default()
+		},
+		..Default::default()
+	}
 }
 
 impl pallet_insecure_randomness_collective_flip::Config for Runtime {}
@@ -315,7 +324,7 @@ impl pallet_assets::Config for Runtime {
 parameter_types! {
 	pub const DepositPerItem: Balance = deposit(1, 0);
 	pub const DepositPerByte: Balance = deposit(0, 1);
-	pub Schedule: pallet_contracts::Schedule<Runtime> = Default::default();
+	pub Schedule: pallet_contracts::Schedule<Runtime> = schedule::<Runtime>();
 	pub const DefaultDepositLimit: Balance = deposit(1024, 1024 * 1024);
 }
 
@@ -350,7 +359,7 @@ impl pallet_contracts::Config for Runtime {
 	type CallFilter = AllowBalancesCall;
 	type DepositPerItem = DepositPerItem;
 	type DepositPerByte = DepositPerByte;
-	type CallStack = [pallet_contracts::Frame<Self>; 31];
+	type CallStack = [pallet_contracts::Frame<Self>; 5];
 	type WeightPrice = pallet_transaction_payment::Pallet<Self>;
 	type WeightInfo = pallet_contracts::weights::SubstrateWeight<Self>;
 	type ChainExtension = pallet_assets_chain_extension::substrate::AssetsExtension;


### PR DESCRIPTION
In recent PR https://github.com/paritytech/substrate-contracts-node/pull/182#issuecomment-1536514910, the CI step of running `cargo test` was commented out as a dirty workaround for the pallet contracts integrity test failure. The test checks that the pallet configuration is memory safe.

So to make the test pass, we enlarge the runtime memory limit in the Schedule. We do this because this development node [allows](https://github.com/paritytech/substrate-contracts-node/blob/8d13ddef3f5c728d1661e79c511a28cef206b298/runtime/src/lib.rs#L367) larger contract size than it is normally allowed in a production running node. This should be fine for the development node where possible security implications could be neglected for the sake of development convenience. **However, please DO NOT do this to your production node config, unless you are sure that the limit you're setting is the real memory limit of your runtime**. 