### PR TITLE
Release `v0.26.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "contracts-node"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "clap",
  "contracts-node-runtime",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "contracts-node-runtime"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "frame-executive",
  "frame-support",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contracts-node"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate node configured for smart contracts via `pallet-contracts`."
 edition = "2021"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contracts-node-runtime"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Unlicense"


### PR DESCRIPTION
#180 upgraded to [polkadot-v0.9.42](https://github.com/paritytech/substrate/tree/polkadot-v0.9.42).

This PR bumps the version to `0.26.0` in preparation for a release tag.