### PR TITLE
feat: delayed finalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ for a production deployment, but a great fit for development and testing:_
   * By default, either manual or instant seal does not result in block finalization unless the `engine_finalizeBlock` 
     RPC is executed. However, it is possible to configure the finalization of sealed blocks to occur after a certain 
     amount of time by setting the `--finalize-delay-sec` option to a specific value, which specifies the number of seconds 
-    to delay before finalizing the blocks. Using a value of `0` would lead to instant finalization, with the blocks being 
-    finalized immediately upon being sealed.
+    to delay before finalizing the blocks. The default value is 1 second.
     ```shell
     ./target/release/substrate-contracts-node --finalize-delay-sec 5
     ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ for a production deployment, but a great fit for development and testing:_
   [#42](https://github.com/paritytech/substrate-contracts-node/pull/42).
   Hereby blocks are authored immediately at every transaction, so there
   is none of the typical six seconds block time associated with `grandpa` or `aura`.
+  * By default, either manual or instant seal does not result in block finalization unless the `engine_finalizeBlock` 
+    RPC is executed. However, it is possible to configure the finalization of sealed blocks to occur after a certain 
+    amount of time by setting the `--finalize-delay-sec` option to a specific value, which specifies the number of seconds 
+    to delay before finalizing the blocks. Using a value of `0` would lead to instant finalization, with the blocks being 
+    finalized immediately upon being sealed.
+    ```shell
+    ./target/release/substrate-contracts-node --finalize-delay-sec 5
+    ```
 * _If no CLI arguments are passed the node is started in development mode
   by default._
 * A custom logging filter is applied by default that hides block production noise

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -84,10 +84,9 @@ pub struct Cli {
 	#[arg(raw = true)]
 	pub relay_chain_args: Vec<String>,
 
-	/// The number of seconds to delay before finalizing blocks. A value of `0` would lead to
-	/// instant finalization.
-	#[clap(long)]
-	pub finalize_delay_sec: Option<u64>,
+	/// The number of seconds to delay before finalizing blocks.
+	#[arg(long, default_value_t = 1)]
+	pub finalize_delay_sec: u8,
 }
 
 #[derive(Debug)]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -84,7 +84,8 @@ pub struct Cli {
 	#[arg(raw = true)]
 	pub relay_chain_args: Vec<String>,
 
-	/// The number of seconds to delay before finalizing blocks. A value of `0` would lead to instant finalization.
+	/// The number of seconds to delay before finalizing blocks. A value of `0` would lead to
+	/// instant finalization.
 	#[clap(long)]
 	pub finalize_delay_sec: Option<u64>,
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -83,6 +83,10 @@ pub struct Cli {
 	/// Relay chain arguments
 	#[arg(raw = true)]
 	pub relay_chain_args: Vec<String>,
+
+	/// The number of seconds to delay before finalizing blocks. A value of `0` would lead to instant finalization.
+	#[clap(long)]
+	pub finalize_delay_sec: Option<u64>,
 }
 
 #[derive(Debug)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -225,7 +225,7 @@ pub fn run() -> Result<()> {
 
 			runner.run_node_until_exit(|config| async move {
 				if config.chain_spec.name() == "Development" { // TODO
-					return service::dev::new_full(config).map_err(sc_cli::Error::Service);
+					return service::dev::new_full(config, cli.finalize_delay_sec).map_err(sc_cli::Error::Service);
 				}
 
 				let hwbench = (!cli.no_hardware_benchmarks)

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -225,7 +225,7 @@ pub fn run() -> Result<()> {
 
 			runner.run_node_until_exit(|config| async move {
 				if config.chain_spec.name() == "Development" { // TODO
-					return service::dev::new_full(config, cli.finalize_delay_sec).map_err(sc_cli::Error::Service);
+					return service::dev::new_full(config, cli.finalize_delay_sec.into()).map_err(sc_cli::Error::Service);
 				}
 
 				let hwbench = (!cli.no_hardware_benchmarks)

--- a/node/src/service/dev.rs
+++ b/node/src/service/dev.rs
@@ -101,7 +101,10 @@ pub fn new_partial(
 	})
 }
 
-pub fn new_full(config: Configuration, finalize_delay_sec: Option<u64>) -> Result<TaskManager, ServiceError> {
+pub fn new_full(
+	config: Configuration,
+	finalize_delay_sec: Option<u64>,
+) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
 		client,
 		backend,


### PR DESCRIPTION
Adds `--finalize-delay-sec` cli argument, based on the great work by @shunsukew at https://github.com/inkdevhub/swanky-node/pull/61.

Manual testing by starting node with/without option, along with example contract upload:
```shell
# build example contract
cargo contract build --manifest-path=../ink-examples/erc20/Cargo.toml

# start node
cargo run

# upload contract
cargo contract upload --suri //Alice --execute --manifest-path=../ink-examples/erc20/Cargo.toml
# check finalized head remains at genesis
sleep 1
test $(curl -sH "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "chainHead_unstable_genesisHash", "params":[]}' http://localhost:9944 | jq .result) \
  = $(curl -sH "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "chain_getFinalizedHead", "params":[]}' http://localhost:9944 | jq .result) && echo PASS || echo FAIL


# start node (with delayed finalization)
cargo run -- --finalize-delay-sec 1

# upload contract
cargo contract upload --suri //Alice --execute --manifest-path=../ink-examples/erc20/Cargo.toml
# check finalized head matches chain head
sleep 1
test $(curl -sH "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "chain_getHead", "params":[]}' http://localhost:9944 | jq .result) \
  = $(curl -sH "Content-Type: application/json" -d '{"id":"1", "jsonrpc":"2.0", "method": "chain_getFinalizedHead", "params":[]}' http://localhost:9944 | jq .result) && echo PASS || echo FAIL

```

Closes #160 