### PR TITLE
Make weight_to_fee work in the solo chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-utility",
  "parity-scale-codec",
+ "polkadot-runtime-common",
  "scale-info",
  "sp-api",
  "sp-block-builder",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -41,6 +41,9 @@ sp-transaction-pool = { workspace = true }
 sp-version = { workspace = true }
 sp-genesis-builder = { workspace = true }
 
+# Polkadot
+polkadot-runtime-common = { workspace = true }
+
 # extra deps for setting up pallet-contracts
 pallet-contracts = { workspace = true }
 pallet-authorship  = { workspace = true }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -9,9 +9,9 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 mod assets_config;
 mod contracts_config;
 
-use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 use frame_support::dispatch::DispatchClass;
 use frame_system::limits::{BlockLength, BlockWeights};
+use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -9,6 +9,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 mod assets_config;
 mod contracts_config;
 
+use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 use frame_support::dispatch::DispatchClass;
 use frame_system::limits::{BlockLength, BlockWeights};
 use sp_api::impl_runtime_apis;
@@ -269,7 +270,7 @@ impl pallet_transaction_payment::Config for Runtime {
 	type OperationalFeeMultiplier = ConstU8<5>;
 	type WeightToFee = IdentityFee<Balance>;
 	type LengthToFee = IdentityFee<Balance>;
-	type FeeMultiplierUpdate = ();
+	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
 }
 
 impl pallet_sudo::Config for Runtime {


### PR DESCRIPTION
It has been reported an issue (https://github.com/paritytech/ink/issues/1985) that weight_to_fee always returns zero in end-to-end tests. 
This pull request adds `type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>` to make it work.