### PR TITLE
Release `0.38.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
 
 [[package]]
 name = "contracts-node"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "clap",
  "color-print",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "contracts-node-runtime"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "contracts-parachain-runtime"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 authors = ["anonymous"]
 edition = "2021"
-version = "0.37.0"
+version = "0.38.0"
 license = "Unlicense"
 homepage = "https://github.com/paritytech/substrate-contracts-node"
 repository = "https://github.com/paritytech/substrate-contracts-node"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,8 +27,8 @@ serde_json = { workspace = true }
 wasmtime = { workspace = true }
 
 # Local
-contracts-parachain-runtime = { path = "../parachain-runtime", features = ["parachain"], version = "0.37.0" }
-contracts-node-runtime = { path = "../runtime",  version = "0.37.0" }
+contracts-parachain-runtime = { path = "../parachain-runtime", features = ["parachain"], version = "0.38.0" }
+contracts-node-runtime = { path = "../runtime",  version = "0.38.0" }
 
 # Substrate
 frame-benchmarking = { workspace = true }


### PR DESCRIPTION
To fix `ink!` CI with https://github.com/paritytech/substrate-contracts-node/pull/224